### PR TITLE
Code of conduct revision

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 This code of conduct outlines expectations for participation in Definity-managed communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community.
 
 ## Our Pledge
-We as members, contributors, and leaders pledge to make participation in our community an open, welcoming, inspiring, diverse, inclusive, healthy, and harassment-free community for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation. We pledge to act, interact, and provide in ways that contribute to it.
+We as members, contributors, and leaders pledge to make participation in our community a welcoming and harassment-free community for everyone, regardless of age, disability, gender identity and expression, level of experience, nationality, personal appearance, race, religion, sexual identity and orientation, or numerous other diversifying features. We pledge to act, interact, and provide in ways that contribute to it.
 
 ## Our Standards
 Examples of behavior that contributes to a positive environment for our community include:
@@ -19,7 +19,7 @@ Examples of unacceptable behavior include:
 * The use of sexualized language or imagery, and sexual attention or advances of any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Disruptive behavior
+* Disruptive behavior, such as harassment, unnecessary hostility, and starting unneeded arguments
 * Publishing others' private information, such as a physical or email address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
@@ -34,13 +34,12 @@ This Code of Conduct applies within all community spaces, and also applies when 
 This Code of Conduct also applies to actions taken outside of these spaces, and which have a negative impact on community health.
 
 ## Enforcement
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [support@definityteam.com](mailto:support@definityteam.com). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [support@definityteam.com](mailto:support@definityteam.com). All complaints will be reviewed and investigated promptly and fairly. Your report should include the username of the user, a screenshot or direct link to what you are complaining about and why you believe this is in violation of our Code of Conduct, and, if possible, what section of it.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 **Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 This code of conduct outlines expectations for participation in Definity-managed communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community.
 
 ## Our Pledge
-We as members, contributors, and leaders pledge to make participation in our community a welcoming and harassment-free community for everyone, regardless of age, disability, gender identity, race, religion, sexual identity and orientation, or numerous other diversifying features. We pledge to act, interact, and provide in ways that contribute to it.
+We as members, contributors, and leaders pledge to make participation in our community welcoming and harassment-free for everyone, regardless of age, disability, gender identity, race, religion, sexual identity and orientation, or numerous other diversifying features. We pledge to act, interact, and provide in ways that contribute.
 
 ## Our Standards
 Examples of behavior that contributes to a positive environment for our community include:
@@ -66,9 +66,9 @@ This Code of Conduct is adapted from
   a) the Microsoft Open Source Code of Conduct, available at https://opensource.microsoft.com/codeofconduct,
   b) the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
 
-Expanding scope to include external impact on community health inspired by [Facebook's Open Source Code of Conduct](https://opensource.facebook.com/code-of-conduct) and [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation).
+Expanding scope to include external impact on community health inspired by [Facebook's Open Source Code of Conduct](https://opensource.fb.com/code-of-conduct) and [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation).
 
 For answers to common questions about the [Contributor Covenant](https://www.contributor-covenant.org) code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. [Contributor Covenant](https://www.contributor-covenant.org) translations are available at https://www.contributor-covenant.org/translations.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,70 +1,43 @@
-# Contributor Covenant Code of Conduct
+# Definity Contributor Code of Conduct
+
+This code of conduct outlines expectations for participation in Definity-managed open source communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community.
 
 ## Our Pledge
-
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
-
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We as members, contributors, and leaders pledge to make participation in our community an open, welcoming, inspiring, diverse, inclusive, healthy, and harassment-free community for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation. We pledge to act, interact, and provide in ways that contribute to it.
 
 ## Our Standards
-
-Examples of behavior that contributes to a positive environment for our
-community include:
+Examples of behavior that contributes to a positive environment for our community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* Disruptive behavior
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct also applies to actions taken outside of these spaces, and which have a negative impact on community health.
 
-## Enforcement
+## Enforcement <!-- todo [L]: make reporting conduct violations its own email + get authorized independent reviewers -->
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-https://discord.gg/vHCPCp7xKH.
-All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [support@definityteam.com](support@definityteam.com). All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 
@@ -73,56 +46,36 @@ the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from
+  a) the Microsoft Open Source Code of Conduct, available at https://opensource.microsoft.com/codeofconduct,
+  b) the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
-[homepage]: https://www.contributor-covenant.org
+Expanding scope to include external impact on community health inspired by [Facebook's Open Source Code of Conduct](https://opensource.facebook.com/code-of-conduct) and [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation).
 
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+For answers to common questions about the [Contributor Covenant](https://www.contributor-covenant.org) code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. [Contributor Covenant](https://www.contributor-covenant.org) translations are available at https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 This code of conduct outlines expectations for participation in Definity-managed communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community.
 
 ## Our Pledge
-We as members, contributors, and leaders pledge to make participation in our community a welcoming and harassment-free community for everyone, regardless of age, disability, gender identity and expression, level of experience, nationality, personal appearance, race, religion, sexual identity and orientation, or numerous other diversifying features. We pledge to act, interact, and provide in ways that contribute to it.
+We as members, contributors, and leaders pledge to make participation in our community a welcoming and harassment-free community for everyone, regardless of age, disability, gender identity, race, religion, sexual identity and orientation, or numerous other diversifying features. We pledge to act, interact, and provide in ways that contribute to it.
 
 ## Our Standards
 Examples of behavior that contributes to a positive environment for our community include:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Definity Contributor Code of Conduct
 ## Preamble
-This code of conduct outlines expectations for participation in Definity-managed open source communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community.
+This code of conduct outlines expectations for participation in Definity-managed communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community.
 
 ## Our Pledge
 We as members, contributors, and leaders pledge to make participation in our community an open, welcoming, inspiring, diverse, inclusive, healthy, and harassment-free community for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation. We pledge to act, interact, and provide in ways that contribute to it.
@@ -34,7 +34,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 This Code of Conduct also applies to actions taken outside of these spaces, and which have a negative impact on community health.
 
 ## Enforcement
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [support@definityteam.com](support@definityteam.com). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [support@definityteam.com](mailto:support@definityteam.com). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Definity Contributor Code of Conduct
-
+## Preamble
 This code of conduct outlines expectations for participation in Definity-managed open source communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community.
 
 ## Our Pledge
@@ -33,43 +33,36 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 This Code of Conduct also applies to actions taken outside of these spaces, and which have a negative impact on community health.
 
-## Enforcement <!-- todo [L]: make reporting conduct violations its own email + get authorized independent reviewers -->
-
+## Enforcement
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [support@definityteam.com](support@definityteam.com). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
-
 Community leaders will follow these Community Impact Guidelines in determining
 the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
-
 **Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
 **Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
-
 **Community Impact**: A violation through a single incident or series of actions.
 
 **Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
-
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
 **Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
-
 **Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
-
 This Code of Conduct is adapted from
   a) the Microsoft Open Source Code of Conduct, available at https://opensource.microsoft.com/codeofconduct,
   b) the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
@@ -79,3 +72,5 @@ Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcem
 Expanding scope to include external impact on community health inspired by [Facebook's Open Source Code of Conduct](https://opensource.facebook.com/code-of-conduct) and [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation).
 
 For answers to common questions about the [Contributor Covenant](https://www.contributor-covenant.org) code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. [Contributor Covenant](https://www.contributor-covenant.org) translations are available at https://www.contributor-covenant.org/translations.
+
+The Microsoft Open Source Code of Conduct is under the MIT license, viewable at https://opensource.microsoft.com/LICENSE. The Contributor Covenant is under the Creative Commons Attribution 4.0 International Public License, viewable at https://creativecommons.org/licenses/by/4.0/legalcode.


### PR DESCRIPTION
## PR changes
This change moves from the basic Contributor Covenant to an independent Definity Contributor Code of Conduct. This code of conduct revision has been adapted from both the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct) and the [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html). 

As of current, it's not much different. Here's the list of changes:
### Draft 1
- Name changed from `Contributor Covenant Code of Conduct` to `Definity Contributor Code of Conduct`
- The raw text of each paragraph is no longer separated every few words, and is now in full width
- Removed numerous newlines between header and following text
- A precursing text has been added, "This code of conduct outlines expectations for participation in Definity-managed open source communities, as well as steps for reporting unacceptable behavior. People violating this code of conduct may be banned from the community."
- The "Our Pledge" section has rewording of "an open, welcoming, inspiring, diverse, inclusive, healthy, and harassment-free community for everyone", adding of "caste, color", and a new sentence has been added, "We pledge to act, interact, and provide in ways that contribute to it."
- Examples of unacceptable behavior now also include "Disruptive behavior"
- The code of conduct scope now applies to actions taken outside of these spaces, *and* which have a negative impact on community health
- A change in violation reporting from Discord to email
- Both adapted codes of conduct have been attributed accordingly
### Draft 2
- Added license attribution for each code of conduct
- Added preamble header
- Removed remaining newlines between header and following text
### Draft 3
- Change from "Definity-managed open source communities" to "Definity-managed communities"
### Draft 4
- Shorten "Our Pledge"
- "Disruptive behavior" has been clarified
- Provide information as to what should be included in a report
- Make "Enforcement Guidelines" first sentence full width
### Draft 5
- Shorten "Our Pledge"
### Draft 6
- Shorten "Our Pledge"
- Update links
## Todo
### Violation reporting
Right now, the email used to report violations is `support@definityteam.com`. This is probably not the best place to send violation reports, since the support inbox is more for solving issues with the things we make, and there's definitely going to be an extreme wait time.

Eventually, this should be its own email-- and as a bonus, we should probably get a dedicated group of people ~~who *cannot* interact with the community~~ alongside steps to verify with the reporter that the people involved with the issue are *not* on the team chosen to investigate. This way, it can be ensured that if people violate the code of conduct, it's not going to anyone who would be of said violation. That group can be for later, though, but it is *very* important.